### PR TITLE
use correct string width in swprintf()

### DIFF
--- a/Windows_Libs/Dev/Storage/STO_DLC.cpp
+++ b/Windows_Libs/Dev/Storage/STO_DLC.cpp
@@ -108,7 +108,7 @@ C4JStorage::EDLCStatus CDLC::GetInstalledDLC(int iPad, int (*Func)(LPVOID, int, 
                     sprintf(data.szFileName, "Windows64Media/DLC/%s", hFind.cFileName);
                 }
 
-                swprintf(data.szDisplayName, 256, L"%s", hFind.cFileName);
+                swprintf(data.szDisplayName, 256, L"%S", hFind.cFileName);
                 int displayNameLen = wcslen(data.szDisplayName);
 
                 data.DeviceID = 0;


### PR DESCRIPTION
The line changed in this PR has the correct behaviour in older versions of Visual C++, but when built with newer versions the char width is wrong and results in the DLC names getting mangled: https://stackoverflow.com/a/23572438