### PR TITLE
Fix PNG text data writing for thumbnails

### DIFF
--- a/impls/Windows_Libs/Storage/src/STO_SaveGame.cpp
+++ b/impls/Windows_Libs/Storage/src/STO_SaveGame.cpp
@@ -461,7 +461,7 @@ void CSaveGame::AddTextFieldToPNG(PBYTE pbImageData, DWORD dwImageBytes, PBYTE p
 
     for (int j = 0; j < 8; ++j)
     {
-        if (CSaveGame::szPNGHeader[j] != pbImageData[j])
+        if (CSaveGame::szPNGHeader[j] != reinterpret_cast<char*>(pbImageData)[j])
         {
             return;
         }


### PR DESCRIPTION
**ISSUE**
The text data associated with a save's thumbnail image does not write properly, this prevents save file information such as host options, seed, and texture pack from being read and applied the next time the save is loaded.
**CAUSE**
This occurs because during a validation of the thumbnail image, a char array is compared against an unsigned char array which results in the check failing, even if the header matches.
**FIX**
This issue is fixed by converting the pbImageData unsigned char (BYTE) pointer to a char pointer before reading the contents.